### PR TITLE
Migration from using creme to river 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-- Sending a `GET` request to `/api/init` now returns more information, including the version of `creme` that is being used.
+- Sending a `GET` request to `/api/init` now returns more information, including the version of `river` that is being used.
 - [Cerberus](https://docs.python-cerberus.org/en/stable/index.html) is used instead of [Marshmallow](https://marshmallow.readthedocs.io/en/stable/) for input validation, which slightly modifies the contents of error messages.
 - The `features` field can now contain text input. Before the only possibility was to pass a dictionary.
+- Migrated from using `creme` to the evolved project under the new name `river` - 2022-01-09
 
 ## [0.2.0](https://pypi.org/project/chantilly/0.2.0/) - 2020-05-02
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 <p align="center">
   <!-- Travis -->
-  <a href="https://travis-ci.org/creme-ml/chantilly">
-    <img src="https://img.shields.io/travis/creme-ml/chantilly/master.svg?style=flat-square" alt="travis">
+  <a href="https://travis-ci.org/online-ml/chantilly">
+    <img src="https://img.shields.io/travis/online-ml/chantilly/master.svg?style=flat-square" alt="travis">
   </a>
   <!-- Codecov -->
-  <a href="https://codecov.io/gh/creme-ml/chantilly">
-    <img src="https://img.shields.io/codecov/c/gh/creme-ml/chantilly.svg?style=flat-square" alt="codecov">
+  <a href="https://codecov.io/gh/online-ml/chantilly">
+    <img src="https://img.shields.io/codecov/c/gh/online-ml/chantilly.svg?style=flat-square" alt="codecov">
   </a>
   <!-- Gitter -->
-  <a href="https://gitter.im/creme-ml/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link">
-    <img src="https://img.shields.io/gitter/room/creme-ml/community?color=blueviolet&style=flat-square" alt="gitter">
+  <a href="https://gitter.im/online-ml/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link">
+    <img src="https://img.shields.io/gitter/room/online-ml/community?color=blueviolet&style=flat-square" alt="gitter">
   </a>
   <!-- PyPI -->
   <a href="https://pypi.org/project/chantilly">
@@ -26,7 +26,7 @@
 </p>
 
 <p align="center">
-  <code>chantilly</code> is a deployment tool for <a href="https://www.wikiwand.com/en/Online_machine_learning">online machine learning</a> models. It is designed to work hand in hand with <a href="https://github.com/creme-ml/creme"><code>creme</code></a>.
+  <code>chantilly</code> is a deployment tool for <a href="https://www.wikiwand.com/en/Online_machine_learning">online machine learning</a> models. It is designed to work hand in hand with <a href="https://github.com/online-ml/river"><code>river</code></a>.
 </p>
 
 ## Table of contents
@@ -81,7 +81,7 @@ Note that `chantilly` is very young, and is therefore subject to evolve. We're a
 You can also install the latest development version as so:
 
 ```sh
-> pip install git+https://github.com/creme-ml/chantilly
+> pip install git+https://github.com/online-ml/chantilly
 ```
 
 ## User guide
@@ -133,9 +133,9 @@ print(r.json()['flavor'])
 You can upload a model by sending a POST request to the `@/api/model` route. You need to provide a model which has been serialized with [`pickle`](https://docs.python.org/3/library/pickle.html) or [`dill`](https://dill.readthedocs.io/en/latest/dill.html) (we recommend the latter). For example:
 
 ```py
-from creme import compose
-from creme import linear_model
-from creme import preprocessing
+from river import compose
+from river import linear_model
+from river import preprocessing
 import dill
 import requests
 
@@ -332,7 +332,7 @@ These statistic are voluntarily very plain. Their only purpose is to provide a q
 You can use different models by giving them names. You can provide a name to a model by adding a suffix to `@/api/model`:
 
 ```py
-from creme import tree
+from river import tree
 import dill
 import requests
 
@@ -445,9 +445,9 @@ Naturally, the values have to be chosen according to your Redis setup.
 It's highly likely that your model will be using external dependencies. A prime example is the [`datetime`](https://docs.python.org/3/library/datetime.html) module, which you'll probably want to use to parse datetime strings. Instead of specifying which libraries you want `chantilly` to import, the current practice is to import your requirements *within* your model. For instance, here is an excerpt taken from the [New-York city taxi trips example](examples/taxis):
 
 ```py
-from creme import compose
-from creme import linear_model
-from creme import preprocessing
+from river import compose
+from river import linear_model
+from river import preprocessing
 
 def parse(trip):
     import datetime as dt
@@ -482,7 +482,7 @@ Essentially, `chantilly` is just a Flask application. Therefore, it allows the s
 ## Development
 
 ```sh
-> git clone https://github.com/creme-ml/chantilly
+> git clone https://github.com/online-ml/chantilly
 > cd chantilly
 > pip install -e ".[dev]"
 > python setup.py develop
@@ -515,7 +515,7 @@ You may also run the app in development mode.
 
 ## Roadmap
 
-- **HTTP long polling**: Currently, clients can interact with `creme` over a straightforward HTTP protocol. Therefore the speed bottleneck comes from the web requests, not from the machine learning. We would like to provide a way to interact with `chantilly` via long-polling. This means that a single connection can be used to process multiple predictions and model updates, which reduces the overall latency.
+- **HTTP long polling**: Currently, clients can interact with `river` over a straightforward HTTP protocol. Therefore the speed bottleneck comes from the web requests, not from the machine learning. We would like to provide a way to interact with `chantilly` via long-polling. This means that a single connection can be used to process multiple predictions and model updates, which reduces the overall latency.
 - **Scaling**: At the moment `chantilly` is designed to be run as a single server. Ideally we want to allow `chantilly` in a multi-server environment. Predictions are simple to scale because the model can be used concurrently. However, updating the model concurrently leads to [reader-write problems](https://www.wikiwand.com/en/Readers%E2%80%93writers_problem). We have some ideas in the pipe, but this is going to need some careful thinking.
 - **Grafana dashboard**: The current dashboard is a quick-and-dirty proof of concept. In the long term, we would like to provide a straighforward way to connect with a [Grafana](https://grafana.com/) instance without having to get your hands dirty. Ideally, we would like to use SQLite as a data source for simplicity reasons. However, The Grafana team [has not planned](https://github.com/grafana/grafana/issues/1542#issuecomment-425684417) to add support for SQLite. Instead, they encourage users to use [plugins](https://grafana.com/docs/grafana/latest/plugins/developing/datasources/). We might also look into [Prometheus](https://prometheus.io/) and [InfluxDB](https://www.influxdata.com/).
 - **Support more paradigms**: For the moment we cater to regression and classification models. In the future we also want to support other paradigms, such as time series forecasting and recommender systems.
@@ -536,4 +536,4 @@ Most machine learning deployment tools only support making predictions with a tr
 
 ## License
 
-`creme` is free and open-source software licensed under the [3-clause BSD license](https://github.com/creme-ml/creme/blob/master/LICENSE).
+`river` is free and open-source software licensed under the [3-clause BSD license](https://github.com/online-ml/river/blob/master/LICENSE).

--- a/chantilly/__version__.py
+++ b/chantilly/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 2, 0)
+VERSION = (0, 3, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/chantilly/api.py
+++ b/chantilly/api.py
@@ -4,8 +4,8 @@ import queue
 import time
 
 import cerberus
-import creme
-from creme.metrics.base import ClassificationMetric
+import river
+from river.metrics.base import ClassificationMetric
 import dill
 import flask
 
@@ -98,7 +98,7 @@ def init():
         return {
             'flavor': flavor.name,
             'storage': flask.current_app.config['STORAGE_BACKEND'],
-            'creme_version': creme.__version__
+            'river_version': river.__version__
         }
 
     # POST: configure chantilly
@@ -314,7 +314,7 @@ def learn():
 
     # Update the model
     try:
-        model.fit_one(x=copy.deepcopy(features), y=payload['ground_truth'])
+        model.learn_one(x=copy.deepcopy(features), y=payload['ground_truth'])
     except Exception as e:
         raise exceptions.InvalidUsage(message=repr(e))
     db[f'models/{model_name}'] = model

--- a/chantilly/flavors.py
+++ b/chantilly/flavors.py
@@ -1,7 +1,7 @@
 import abc
 import typing
 
-from creme import metrics
+from river import metrics
 
 
 def allowed_flavors():
@@ -34,7 +34,7 @@ class RegressionFlavor(Flavor):
         return 'regression'
 
     def check_model(self, model):
-        for method in ('fit_one', 'predict_one'):
+        for method in ('learn_one', 'predict_one'):
             if not hasattr(model, method):
                 return False, f'The model does not implement {method}.'
         return True, None
@@ -54,7 +54,7 @@ class BinaryFlavor(Flavor):
         return 'binary'
 
     def check_model(self, model):
-        for method in ('fit_one', 'predict_proba_one'):
+        for method in ('learn_one', 'predict_proba_one'):
             if not hasattr(model, method):
                 return False, f'The model does not implement {method}.'
         return True, None
@@ -80,7 +80,7 @@ class MultiClassFlavor(Flavor):
         return 'multiclass'
 
     def check_model(self, model):
-        for method in ('fit_one', 'predict_proba_one'):
+        for method in ('learn_one', 'predict_proba_one'):
             if not hasattr(model, method):
                 return False, f'The model does not implement {method}.'
         return True, None

--- a/chantilly/storage.py
+++ b/chantilly/storage.py
@@ -4,10 +4,10 @@ import os
 import random
 import shelve
 
-import creme.base
-import creme.metrics
-import creme.stats
-import creme.utils
+import river.base
+import river.metrics
+import river.stats
+import river.utils
 import dill
 import flask
 try:
@@ -160,10 +160,10 @@ def set_flavor(flavor: str):
 def init_stats():
     db = get_db()
     db['stats'] = {
-        'learn_mean': creme.stats.Mean(),
-        'learn_ewm': creme.stats.EWMean(.3),
-        'predict_mean': creme.stats.Mean(),
-        'predict_ewm': creme.stats.EWMean(.3),
+        'learn_mean': river.stats.Mean(),
+        'learn_ewm': river.stats.EWMean(.3),
+        'predict_mean': river.stats.Mean(),
+        'predict_ewm': river.stats.EWMean(.3),
     }
 
 def init_metrics():
@@ -177,7 +177,7 @@ def init_metrics():
     db['metrics'] = flavor.default_metrics()
 
 
-def add_model(model: creme.base.Estimator, name: str = None) -> str:
+def add_model(model: river.base.Estimator, name: str = None) -> str:
 
     db = get_db()
 

--- a/examples/docker-compose/test.py
+++ b/examples/docker-compose/test.py
@@ -1,6 +1,6 @@
-from creme import datasets
-from creme import linear_model
-from creme import preprocessing
+from river import datasets
+from river import linear_model
+from river import preprocessing
 import dill
 import requests
 

--- a/examples/taxis/README.md
+++ b/examples/taxis/README.md
@@ -14,12 +14,12 @@ Before running the simulation, let's start the `chantilly` server. For the purpo
 > chantilly run
 ```
 
-Let's now create a model using `creme`. Simply run the following snippet in a Python interpreter.
+Let's now create a model using `river`. Simply run the following snippet in a Python interpreter.
 
 ```py
-from creme import compose
-from creme import linear_model
-from creme import preprocessing
+from river import compose
+from river import linear_model
+from river import preprocessing
 
 
 def parse(trip):

--- a/examples/taxis/simulate.py
+++ b/examples/taxis/simulate.py
@@ -3,9 +3,9 @@ import datetime as dt
 import json
 import time
 
-from creme import datasets
-from creme import metrics
-from creme import stream
+from river import datasets
+from river import metrics
+from river import stream
 import requests
 
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'cerberus>=1.3.2',
-        'creme>=0.5.0',
+        'river>=0.9.0',
         'dill>=0.3.1.1',
         'Flask>=1.1.1'
     ],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,10 +3,10 @@ import pickle
 import pytest
 import uuid
 
-import creme
-from creme import datasets
-from creme import linear_model
-from creme import preprocessing
+import river
+from river import datasets
+from river import linear_model
+from river import preprocessing
 import flask
 
 from chantilly import storage
@@ -54,7 +54,7 @@ def test_init(client, app):
     assert client.get('/api/init').json == {
         'storage': app.config['STORAGE_BACKEND'],
         'flavor': 'regression',
-        'creme_version': creme.__version__
+        'river_version': river.__version__
     }
 
 
@@ -72,11 +72,11 @@ class ModelWithoutFit:
 
 def test_model_without_fit(client, app, regression):
     r = client.post('/api/model', data=pickle.dumps(ModelWithoutFit()))
-    assert r.json == {'message': 'The model does not implement fit_one.'}
+    assert r.json == {'message': 'The model does not implement learn_one.'}
 
 
 class ModelWithoutPredict:
-    def fit_one(self, x, y):
+    def learn_one(self, x, y):
         return self
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import pickle
 import os
 import uuid
 
-from creme import linear_model
+from river import linear_model
 
 from chantilly import cli
 from chantilly import storage

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -2,11 +2,11 @@ import json
 import math
 import pickle
 
-from creme import datasets
-from creme import feature_extraction
-from creme import linear_model
-from creme import naive_bayes
-from creme import preprocessing
+from river import datasets
+from river import feature_extraction
+from river import linear_model
+from river import naive_bayes
+from river import preprocessing
 
 
 def test_phishing(client, app):
@@ -29,9 +29,9 @@ def test_phishing(client, app):
             content_type='application/json'
         )
 
-        # Predict/learn directly via creme
+        # Predict/learn directly via river
         y_pred = model.predict_proba_one(x)
-        model.fit_one(x, y)
+        model.learn_one(x, y)
 
         # Compare the predictions from both sides
         assert math.isclose(y_pred[True], r.json['prediction']['true'])
@@ -56,14 +56,14 @@ def test_phishing_without_id(client, app):
             content_type='application/json'
         )
 
-        # Predict/learn directly via creme
+        # Predict/learn directly via river
         y_pred = model.predict_proba_one(x)
 
         # Because no ID is provided, chantilly will ask the model to make a prediction a second
         # time in order to update the metric
         model.predict_proba_one(x)
 
-        model.fit_one(x, y)
+        model.learn_one(x, y)
 
         # Compare the predictions from both sides
         assert math.isclose(y_pred[True], r.json['prediction']['true'])
@@ -91,9 +91,9 @@ def test_text_input(client, app):
         )
         assert l.status_code == 201
 
-         # Predict/learn directly via creme
+         # Predict/learn directly via river
         y_pred = model.predict_proba_one(x['body'])
-        model.fit_one(x['body'], y)
+        model.learn_one(x['body'], y)
 
         # Compare the predictions from both sides
         assert y_pred.get(True) == p.json['prediction'].get('true')


### PR DESCRIPTION
This PR has updated `chantilly` to the usage of `river`, the evolved version of `creme`.

It is updated across the entire project, hence a very large set of changes.  Mainly, any reference to `creme` was simply changed to `river` and references to `fit_one`, changed to `learn_one`.  Tests ran successfully and the changelog was updated.  Please let me know if more updates are required or you have any comments.  The docker-compose example will not work correctly until a new version of `chantilly` is release to PyPI, however.

Additionally, I want to thank you for this awesome project.  I am working to deploy it using the docker-compose example to a VM in Azure and can add instructions at a later time.  Best Regards, Micheleen